### PR TITLE
Enable Wifi persistent mode

### DIFF
--- a/src/parking_assistant.ino
+++ b/src/parking_assistant.ino
@@ -1215,6 +1215,7 @@ void handleOnboard() {
 #endif
   WiFi.mode(WIFI_STA);
   WiFi.hostname(wifiHostName);
+  WiFi.persistent(true);
   WiFi.begin(wifiSSID, wifiPW);
 #if defined(SERIAL_DEBUG) && (SERIAL_DEBUG == 1)
   Serial.print("SSID:");


### PR DESCRIPTION
This solves the issues during first time setup after first flashing (tried with D1 mini) where the board (d1 mini) is able to connect to wifi router just after saving ssid and password details in the wifi setup form. However, after reboot for some reason the wifi and ssid becomes empty (probably not saved in flash), thus not able to connect to the wifi router and start the AP mode. Adding persistent mode solves the issue and wifi connects successfully after any subsequent restarts. This issue probably occur when the WiFi library used for very first time.
Hopefully it helps someone.

@Resinchem  Thanks for the documentation and code! You must have spent a lot of time testing, designing and coding.